### PR TITLE
Html workaround

### DIFF
--- a/src/main/java/com/quran/tajweed/model/Result.java
+++ b/src/main/java/com/quran/tajweed/model/Result.java
@@ -1,14 +1,22 @@
 package com.quran.tajweed.model;
 
 public class Result {
-  public final int start;
-  public final int ending;
+  public int start;
+  public int ending;
   public final ResultType resultType;
 
   public Result(ResultType resultType, int start, int ending) {
     this.start = start;
     this.ending = ending;
     this.resultType = resultType;
+  }
+
+  public void setMinimumStartingPosition(int newStart) {
+    start = newStart;
+  }
+
+  public void setMaximumEndingPosition(int newEnd) {
+    ending = newEnd;
   }
 
   public int getMinimumStartingPosition() {
@@ -18,4 +26,5 @@ public class Result {
   public int getMaximumEndingPosition() {
     return ending;
   }
+
 }

--- a/src/main/java/com/quran/tajweed/model/ResultUtil.java
+++ b/src/main/java/com/quran/tajweed/model/ResultUtil.java
@@ -1,5 +1,6 @@
 package com.quran.tajweed.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ResultUtil {
@@ -16,5 +17,22 @@ public class ResultUtil {
   public void sort(List<Result> results) {
     // note that this Comparator imposes an order inconsistent with equals
     results.sort((o1, o2) -> o1.getMinimumStartingPosition() - o2.getMinimumStartingPosition());
+    // the following will delete portions of overlapping rules
+    List<Result> removeMe = new ArrayList<>();
+    for (int index = 1; index < results.size(); index++) {
+      Result result = results.get(index);
+      Result previousResult = results.get(index - 1);
+      int min = result.getMinimumStartingPosition();
+      int previousMax = previousResult.getMaximumEndingPosition();
+      if(previousMax > min){
+        if(previousResult.resultType.equals(ResultType.GHUNNA) || previousMax - min <= 0) {
+          removeMe.add(previousResult);
+        }
+        else {
+          previousResult.setMaximumEndingPosition(previousMax - (previousMax - min));
+        }
+      }
+    }
+    results.removeAll(removeMe);
   }
 }


### PR DESCRIPTION
Currently the Html exporter is broken because of possibility of overlapping rules. This will fix #11 since overlapping entries are removed/modified. Look at individual commits for more details.
